### PR TITLE
If Platform.SHARE_WEBPAGE is not set, the action sharing website to wechat sometimes fails.

### DIFF
--- a/SocializationSample/src/cn/sharesdk/onekeyshare/OnekeyShare.java
+++ b/SocializationSample/src/cn/sharesdk/onekeyshare/OnekeyShare.java
@@ -80,6 +80,7 @@ public class OnekeyShare {
 	/** url在微信（包括好友、朋友圈收藏）和易信（包括好友和朋友圈）中使用，否则可以不提供 */
 	public void setUrl(String url) {
 		params.put("url", url);
+		params.put("shareType", Platform.SHARE_WEBPAGE);
 	}
 
 	/** filePath是待分享应用程序的本地路劲，仅在微信（易信）好友和Dropbox中使用，否则可以不提供 */


### PR DESCRIPTION
Through some tests, I am sure about this action will enhance the code stability.